### PR TITLE
Support PHP 8.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
             tag: << parameters.version >>
         parameters:
             version:
-                default: "7.4"
+                default: "8.2"
                 description: The `cimg/php` Docker image version tag.
                 type: string
             install-flags:
@@ -154,7 +154,7 @@ jobs:
             - when:
                   condition:
                       and:
-                          - equal: [ "8.1", <<parameters.version>> ]
+                          - equal: [ "8.2", <<parameters.version>> ]
                           - equal: [ "", <<parameters.install-flags>> ]
                   steps:
                       - run-phpunit-tests:
@@ -164,7 +164,7 @@ jobs:
                   condition:
                       not:
                           and:
-                              - equal: [ "8.1", <<parameters.version>> ]
+                              - equal: [ "8.2", <<parameters.version>> ]
                               - equal: [ "", <<parameters.install-flags>> ]
                   steps:
                       - run-phpunit-tests:
@@ -176,5 +176,5 @@ workflows:
             - matrix-conditions:
                   matrix:
                       parameters:
-                          version: ["8.2", "7.4", "8.0", "8.1"]
+                          version: ["7.4", "8.0", "8.1", "8.2"]
                           install-flags: ["", "--prefer-lowest"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,5 +176,5 @@ workflows:
             - matrix-conditions:
                   matrix:
                       parameters:
-                          version: ["7.4", "8.0", "8.1"]
+                          version: ["8.2", "7.4", "8.0", "8.1"]
                           install-flags: ["", "--prefer-lowest"]

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "require-dev": {
         "phpunit/phpunit": "^9.6",
         "rector/rector": "^0.15.17",
-        "squizlabs/php_codesniffer": "^3.7"
+        "squizlabs/php_codesniffer": "^3.7",
+        "symfony/phpunit-bridge": "^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,9 +6,16 @@
             <directory suffix=".php">src</directory>
         </include>
     </coverage>
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
+    <php>
+        <!-- Don't fail for external dependencies. -->
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
+    </php>
     <testsuites>
         <testsuite name="all">
-            <directory suffix="Test.php">test</directory>
+            <directory>test</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -8,36 +8,41 @@ use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
 use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
-use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
+use Rector\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ArrayShapeFromConstantArrayReturnRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector;
 
 return static function (RectorConfig $rectorConfig): void {
-
-    $rectorConfig->phpVersion(PhpVersion::PHP_74);
-
     $rectorConfig->paths([
         __DIR__ . '/src',
         __DIR__ . '/test',
-        __DIR__ . '/rector.php',
     ]);
 
+    // Our base version of PHP.
+    $rectorConfig->phpVersion(PhpVersion::PHP_74);
+
     $rectorConfig->sets([
+        SetList::PHP_82,
         // Please no dead code or unneeded variables.
         SetList::DEAD_CODE,
         // Try to figure out type hints.
         SetList::TYPE_DECLARATION,
-        // Bring us up to PHP 7.4.
-        LevelSetList::UP_TO_PHP_74,
     ]);
 
     $rectorConfig->skip([
         // Don't throw errors on JSON parse problems. Yet.
         // @todo Throw errors and deal with them appropriately.
         JsonThrowOnErrorRector::class,
-        // We like our tags.
+        // We like our tags. Please don't remove them.
         RemoveUselessParamTagRector::class,
         RemoveUselessReturnTagRector::class,
         RemoveUselessVarTagRector::class,
+        ArrayShapeFromConstantArrayReturnRector::class,
+        AddMethodCallBasedStrictParamTypeRector::class,
+        AddArrowFunctionReturnTypeRector::class,
+        ReturnTypeFromStrictTypedCallRector::class,
     ]);
 
     $rectorConfig->importNames();

--- a/rector.php
+++ b/rector.php
@@ -1,26 +1,45 @@
 <?php
 
-/**
- * Generic PHP 7.4 update.
- */
-
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Set\ValueObject\LevelSetList;
+use Rector\Core\ValueObject\PhpVersion;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
+use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
 
 return static function (RectorConfig $rectorConfig): void {
+
+    $rectorConfig->phpVersion(PhpVersion::PHP_74);
+
     $rectorConfig->paths([
         __DIR__ . '/src',
         __DIR__ . '/test',
+        __DIR__ . '/rector.php',
     ]);
 
     $rectorConfig->sets([
+        // Please no dead code or unneeded variables.
+        SetList::DEAD_CODE,
+        // Try to figure out type hints.
+        SetList::TYPE_DECLARATION,
+        // Bring us up to PHP 7.4.
         LevelSetList::UP_TO_PHP_74,
     ]);
 
     $rectorConfig->skip([
+        // Don't throw errors on JSON parse problems. Yet.
+        // @todo Throw errors and deal with them appropriately.
         JsonThrowOnErrorRector::class,
+        // We like our tags.
+        RemoveUselessParamTagRector::class,
+        RemoveUselessReturnTagRector::class,
+        RemoveUselessVarTagRector::class,
     ]);
+
+    $rectorConfig->importNames();
+    $rectorConfig->importShortClasses(false);
 };

--- a/src/Mock/IdGenerator/Sequential.php
+++ b/src/Mock/IdGenerator/Sequential.php
@@ -7,7 +7,7 @@ use Contracts\IdGeneratorInterface;
 class Sequential implements IdGeneratorInterface
 {
     private int $id = 0;
-    public function generate()
+    public function generate(): int
     {
         $this->id++;
         return $this->id;

--- a/src/Mock/Storage/JsonObjectMemory.php
+++ b/src/Mock/Storage/JsonObjectMemory.php
@@ -37,27 +37,27 @@ class JsonObjectMemory extends Memory implements
         return parent::store($data, $id);
     }
 
-    public function conditionByIsEqualTo(string $property, string $value)
+    public function conditionByIsEqualTo(string $property, string $value): void
     {
         $this->conditions[$property][] = $value;
     }
 
-    public function limitTo(int $number_of_items)
+    public function limitTo(int $number_of_items): void
     {
         $this->limit = $number_of_items;
     }
 
-    public function offsetBy(int $offset)
+    public function offsetBy(int $offset): void
     {
         $this->offset = $offset;
     }
 
-    public function sortByAscending(string $property)
+    public function sortByAscending(string $property): void
     {
         $this->sorts['ascend'][] = $property;
     }
 
-    public function sortByDescending(string $property)
+    public function sortByDescending(string $property): void
     {
         $this->sorts['descend'][] = $property;
     }
@@ -100,7 +100,7 @@ class JsonObjectMemory extends Memory implements
         return $results;
     }
 
-    private function resetFilters()
+    private function resetFilters(): void
     {
         $this->offset = 0;
         $this->limit = 0;
@@ -124,7 +124,7 @@ class JsonObjectMemory extends Memory implements
         }
     }
 
-    private function compare($a, $b, $property)
+    private function compare($a, $b, $property): int
     {
         $a = json_decode($a);
         $b = json_decode($b);

--- a/src/StorerInterface.php
+++ b/src/StorerInterface.php
@@ -4,20 +4,20 @@ namespace Contracts;
 
 interface StorerInterface
 {
-  /**
-   * Store.
-   *
-   * @param string|HydratableInterface $data
-   *   The data to be stored.
-   * @param string $id
-   *   The identifier for the data. If the act of storing generates the
-   *   id, there is no need to pass one.
-   *
-   * @return string
-   *   The identifier.
-   *
-   * @throws \Exception
-   *   Issues storing the data.
-   */
+    /**
+     * Store.
+     *
+     * @param string|HydratableInterface $data
+     *   The data to be stored.
+     * @param string|null $id
+     *   The identifier for the data. If the act of storing generates the
+     *   id, there is no need to pass one.
+     *
+     * @return string
+     *   The identifier.
+     *
+     * @throws \Exception
+     *   Issues storing the data.
+     */
     public function store($data, string $id = null): string;
 }

--- a/test/Mock/IdGenerator/SequentialTest.php
+++ b/test/Mock/IdGenerator/SequentialTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class SequentialTest extends TestCase
 {
-    public function test()
+    public function test(): void
     {
         $generator = new Sequential();
         $id1 = $generator->generate();

--- a/test/Mock/Storage/MemoryTest.php
+++ b/test/Mock/Storage/MemoryTest.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace ContractsTest;
 
+use PHPUnit\Framework\TestCase;
+use Contracts\Mock\Storage\Memory;
+use Contracts\Mock\Storage\JsonObjectMemory;
 use Contracts\Mock\Storage\MemoryFactory;
 
-class MemoryTest extends \PHPUnit\Framework\TestCase
+class MemoryTest extends TestCase
 {
-    public function testStorageMemoryException()
+    public function testStorageMemoryException(): void
     {
         $factory = new MemoryFactory();
         $store = $factory->getInstance("store");
@@ -17,9 +20,9 @@ class MemoryTest extends \PHPUnit\Framework\TestCase
         $store->store("Data");
     }
 
-    public function testStorageMemory()
+    public function testStorageMemory(): void
     {
-        $store = new \Contracts\Mock\Storage\Memory();
+        $store = new Memory();
 
         $store->store("Data", "1");
         $this->assertEquals("Data", $store->retrieve("1"));
@@ -37,7 +40,7 @@ class MemoryTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($store->retrieve("1"));
     }
 
-    public function testStorageJsonObjectMemory()
+    public function testStorageJsonObjectMemory(): void
     {
         $objects = [];
         $objects[] = <<<JSON
@@ -68,7 +71,7 @@ JSON;
 }
 JSON;
 
-        $store = new \Contracts\Mock\Storage\JsonObjectMemory();
+        $store = new JsonObjectMemory();
 
 
         foreach ($objects as $index => $object) {


### PR DESCRIPTION
- Adds PHP 8.2 to the test matrix.
- Tweaks rector.php to give us some code quality.
- `composer.json` already says: ```"require": {
        "php": ">=7.4 <9.0"
    },```