### PR TITLE
Add PHP 8.3 to our testing matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
             tag: << parameters.version >>
         parameters:
             version:
-                default: "8.2"
+                default: "8.3"
                 description: The `cimg/php` Docker image version tag.
                 type: string
             install-flags:
@@ -154,7 +154,7 @@ jobs:
             - when:
                   condition:
                       and:
-                          - equal: [ "8.2", <<parameters.version>> ]
+                          - equal: [ "8.3", <<parameters.version>> ]
                           - equal: [ "", <<parameters.install-flags>> ]
                   steps:
                       - run-phpunit-tests:
@@ -164,7 +164,7 @@ jobs:
                   condition:
                       not:
                           and:
-                              - equal: [ "8.2", <<parameters.version>> ]
+                              - equal: [ "8.3", <<parameters.version>> ]
                               - equal: [ "", <<parameters.install-flags>> ]
                   steps:
                       - run-phpunit-tests:
@@ -176,5 +176,5 @@ workflows:
             - matrix-conditions:
                   matrix:
                       parameters:
-                          version: ["7.4", "8.0", "8.1", "8.2"]
+                          version: ["7.4", "8.0", "8.1", "8.2", "8.3"]
                           install-flags: ["", "--prefer-lowest"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.ddev
 .idea
 .phpunit.result.cache
 vendor

--- a/rector.php
+++ b/rector.php
@@ -3,28 +3,21 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Core\ValueObject\PhpVersion;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
 use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
 use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Set\ValueObject\SetList;
-use Rector\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector;
-use Rector\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector;
-use Rector\TypeDeclaration\Rector\ClassMethod\ArrayShapeFromConstantArrayReturnRector;
-use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
         __DIR__ . '/src',
         __DIR__ . '/test',
+        __DIR__ . '/rector.php',
     ]);
 
-    // Our base version of PHP.
-    $rectorConfig->phpVersion(PhpVersion::PHP_74);
-
     $rectorConfig->sets([
-        SetList::PHP_82,
+        SetList::PHP_74,
         // Please no dead code or unneeded variables.
         SetList::DEAD_CODE,
         // Try to figure out type hints.
@@ -39,12 +32,9 @@ return static function (RectorConfig $rectorConfig): void {
         RemoveUselessParamTagRector::class,
         RemoveUselessReturnTagRector::class,
         RemoveUselessVarTagRector::class,
-        ArrayShapeFromConstantArrayReturnRector::class,
-        AddMethodCallBasedStrictParamTypeRector::class,
-        AddArrowFunctionReturnTypeRector::class,
-        ReturnTypeFromStrictTypedCallRector::class,
     ]);
 
+    $rectorConfig->removeUnusedImports();
     $rectorConfig->importNames();
     $rectorConfig->importShortClasses(false);
 };

--- a/src/CountableInterface.php
+++ b/src/CountableInterface.php
@@ -2,8 +2,6 @@
 
 namespace Contracts;
 
-use phpDocumentor\Reflection\Types\Integer;
-
 interface CountableInterface
 {
     public function count(): int;

--- a/src/Mock/Storage/JsonObjectMemory.php
+++ b/src/Mock/Storage/JsonObjectMemory.php
@@ -85,7 +85,7 @@ class JsonObjectMemory extends Memory implements
 
         foreach ($this->sorts as $type => $properties) {
             foreach ($properties as $property) {
-                usort($results, fn($a, $b) => $this->compare($a, $b, $property));
+                usort($results, fn($a, $b): int => $this->compare($a, $b, $property));
 
                 if ($type == 'descend') {
                       $results = array_reverse($results);


### PR DESCRIPTION
- Adding PHP 8.3 to tests.
- We allow PHP < 9.0 already.
- Improve rector, cs.